### PR TITLE
📝 fix anyjump_definition -> anyjump_reference

### DIFF
--- a/README.pod
+++ b/README.pod
@@ -65,7 +65,7 @@ call ddu#custom#patch_global(#{
     \     },
     \   },
     \   sourceParams: #{
-    \     anyjump_definition: #{
+    \     anyjump_reference: #{
     \       highlights: #{
     \         path: 'Normal',
     \         lineNr: 'Normal',


### PR DESCRIPTION
Both configuration examples in the documentation were anyjump_definition, so I have fixed them.